### PR TITLE
Handle search service errors gracefully and improve logging with an o…

### DIFF
--- a/Resources/Private/Templates/Details.html
+++ b/Resources/Private/Templates/Details.html
@@ -7,8 +7,16 @@
 <f:variable name="languageFilePath">LLL:EXT:{settings.extensionName}/Resources/Private/Language/{settings.languageFile}.xlf</f:variable>
 <f:render partial="DetailBreadcrumb" arguments="{_all}" />
 <main role="main" id="page-content">
-    <div class="container-xl sidebar-left grid grid-3col-md searchdetail">
-
+<div class="container-xl sidebar-left grid grid-3col-md searchdetail">
+<f:if condition="{ElasticSearchServiceError} != ''">
+<f:then>
+<div class="content grid-colspan-md-2">
+    <div class="alert" role="alert">
+        {ElasticSearchServiceError}
+    </div>
+</div>
+</f:then>
+<f:else>
 <aside class="sidebar">
     <div class="frame frame-small-mb">
         <h3 class="searchdetail-itemtype">
@@ -97,15 +105,13 @@
             </div>
 
         </dl>
-
-
         <f:if condition="{searchContext.navigation}">
             <f:render partial="DetailPageNavigation" arguments="{detailPageId: detailPageId, searchContext: searchContext, searchPageId: searchPageId }" />
         </f:if>
-
-
     </div>
 </div>
+</f:else>
+</f:if>
 </div>
 </main>
 

--- a/Resources/Private/Templates/DetailsHeader.html
+++ b/Resources/Private/Templates/DetailsHeader.html
@@ -1,7 +1,15 @@
 {namespace lb=Slub\LisztBibliography\ViewHelpers}
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <div class="page-header-title page-header-title-detailpage">
-    <p class="page-header-subtitle"  style="view-transition-name: detail-sub-{searchResult._id};">{lb:searchResultItemHeader(creators: searchResult._source.creators)}</p>
-    <h1 style="view-transition-name: detail-headline-{searchResult._id};">{searchResult._source.title}</h1>
+    <f:if condition="{ElasticSearchServiceError} != ''">
+        <f:then>
+            <p class="page-header-subtitle"> </p>
+            <h1>Error</h1>
+        </f:then>
+        <f:else>
+            <p class="page-header-subtitle"  style="view-transition-name: detail-sub-{searchResult._id};">{lb:searchResultItemHeader(creators: searchResult._source.creators)}</p>
+            <h1 style="view-transition-name: detail-headline-{searchResult._id};">{searchResult._source.title}</h1>
+        </f:else>
+    </f:if>
 </div>
 </html>


### PR DESCRIPTION
now the frontend shows an (simple) error message if elastic service returns an error or is down and the full error message is logged in an new separate logfile 'liszt_common_searcherrors.log'